### PR TITLE
Enable typography styling for markdown content

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,6 +14,7 @@ const {
   includeSidebar = true,
   sideBarActiveItemID,
   ogType,
+  useProse = true,
 } = Astro.props;
 ---
 
@@ -36,7 +37,13 @@ const {
         <Header title={SITE_TITLE} />
         <div class="md:flex md:justify-center">
           <main class="p-6 pt-10 lg:max-w-[900px] max-w-[100vw] w-full h-full">
-            <slot />
+            {useProse ? (
+              <article class="prose md:prose-lg dark:prose-invert max-w-none">
+                <slot />
+              </article>
+            ) : (
+              <slot />
+            )}
           </main>
         </div>
         <Footer />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,7 +2,7 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
-<BaseLayout title = "404: Not Found" includeSidebar={false}>
+<BaseLayout title = "404: Not Found" includeSidebar={false} useProse={false}>
   <div class="text-center">
     <h1 class="text-9xl font-bold mb-4">🏝</h1>
     <h1 class="text-9xl font-bold mb-2">404</h1>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 .time-line-container>div:last-child .education__time>.education__line {
     display: none;
 }


### PR DESCRIPTION
## Summary
- enable tailwindcss base styles
- wrap page content in a `prose` article
- allow disabling typography on 404 page

## Testing
- `pnpm install`
- `pnpm run build` *(fails: EnvInvalidVariables)*

------
https://chatgpt.com/codex/tasks/task_e_6869c442a79883328c6929ea7f127c96