### PR TITLE
Pin decap CMS version

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -8,6 +8,10 @@
     <link href="admin/config.yml" type="text/yaml" rel="cms-config-url">
   </head>
   <body>
-    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+    <script
+      src="https://unpkg.com/decap-cms@3.0.4/dist/decap-cms.js"
+      integrity="sha384-RjpoGRpUGg1p+ypJVafvVW4tqDM8iiKI8V9znLHZh8h/wjNflwvVrUENSW38fLCO"
+      crossorigin="anonymous"
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- pin decap CMS CDN version
- add SRI hash and `crossorigin` attribute

## Testing
- `npm run build` *(fails: EnvInvalidVariables)*

------
https://chatgpt.com/codex/tasks/task_e_6869c58c50dc83329009bf8e0abe8a95