### PR TITLE
Add Vercel headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline'"
+        },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "same-origin" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` to configure security headers for all routes

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm build` *(fails: missing OAUTH_GITHUB_CLIENT_ID and OAUTH_GITHUB_CLIENT_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_6869c5914ff483329267774a7ae5341c