### PR TITLE
Fix CSP for local images

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline'"
+          "value": "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline'"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "same-origin" }


### PR DESCRIPTION
## Summary
- allow data URIs for images in the Vercel CSP configuration

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: required environment variables missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869c9fb13a483328bac1a082070221a