### PR TITLE
Fix decap admin by updating CSP

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline'"
+          "value": "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com; style-src 'self' 'unsafe-inline'"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "same-origin" }


### PR DESCRIPTION
## Summary
- include `unsafe-eval` in `vercel.json` to let Decap CMS load

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: `astro` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869e23a890083328592798274e2b06f