### PR TITLE
Fix CSP for GitHub avatars

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; connect-src 'self' https://api.github.com https://github.com; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com; style-src 'self' 'unsafe-inline'"
+          "value": "default-src 'self'; connect-src 'self' https://api.github.com https://github.com; img-src 'self' data: https://avatars.githubusercontent.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com; style-src 'self' 'unsafe-inline'"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "same-origin" }


### PR DESCRIPTION
## Summary
- allow GitHub avatar URLs in `img-src` directive

## Testing
- `npm run lint` *(fails: couldn't find an eslint.config file)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6869f3b391708332a911242ec25c89b9