### PR TITLE
Add MDX component for image + text blocks

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -16,6 +16,7 @@ collections:
   - name: pages
     label: Pages
     folder: "src/content/pages"
+    extension: mdx
     delete: false
     show_preview_links: false
     fields:

--- a/src/components/ImageTextBlock.astro
+++ b/src/components/ImageTextBlock.astro
@@ -1,0 +1,10 @@
+---
+const { src, alt } = Astro.props
+---
+
+<div class="flex flex-col md:flex-row items-center gap-4">
+  <img src={src} alt={alt} class="md:w-1/2 w-full" />
+  <div class="md:w-1/2 w-full">
+    <slot />
+  </div>
+</div>

--- a/src/content/pages/home.md
+++ b/src/content/pages/home.md
@@ -1,8 +1,0 @@
----
-title: Home
-description: Welcome to Fog City Jazz
----
-
-# Welcome to **Fog City Jazz**.
-
-Homepage under construction! Please come back soon.

--- a/src/content/pages/home.mdx
+++ b/src/content/pages/home.mdx
@@ -1,0 +1,15 @@
+---
+title: Home
+description: Welcome to Fog City Jazz
+---
+
+import ImageTextBlock from "@components/ImageTextBlock.astro"
+
+# Welcome to **Fog City Jazz**.
+
+<ImageTextBlock src="/media/fogcity.webp" alt="Fog City Jazz logo">
+  Welcome to the site! This block shows how you can mix images with text using a
+  reusable component.
+</ImageTextBlock>
+
+Homepage under construction! Please come back soon.


### PR DESCRIPTION
## Summary
- add reusable `ImageTextBlock` Astro component
- convert homepage to MDX and demonstrate component usage
- allow Decap CMS pages to default to MDX

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_6869fb8b453483328c6bdb933500f39f