### PR TITLE
Enable Decap custom block

### DIFF
--- a/public/admin/cms.js
+++ b/public/admin/cms.js
@@ -1,0 +1,23 @@
+CMS.registerEditorComponent({
+  id: "ImageTextBlock",
+  label: "Image + Text",
+  fields: [
+    { name: "src", label: "Image URL", widget: "string" },
+    { name: "alt", label: "Image Alt", widget: "string" },
+    { name: "content", label: "Text", widget: "markdown" },
+  ],
+  pattern: /^<ImageTextBlock src="([^"]+)" alt="([^"]+)">([\s\S]*?)<\/ImageTextBlock>$/,
+  fromBlock: function(match) {
+    return {
+      src: match[1],
+      alt: match[2],
+      content: match[3].trim(),
+    };
+  },
+  toBlock: function(obj) {
+    return `<ImageTextBlock src="${obj.src}" alt="${obj.alt}">\n${obj.content}\n</ImageTextBlock>`;
+  },
+  toPreview: function(obj) {
+    return `<div class="flex flex-col md:flex-row items-center gap-4"><img src="${obj.src}" alt="${obj.alt}" style="width:48%;"/><div style="width:48%;">${obj.content}</div></div>`;
+  },
+});

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -11,12 +11,15 @@ public_folder: "/media"
 
 editor:
   preview: false
+  editorComponents:
+    - ImageTextBlock
 
 collections:
   - name: pages
     label: Pages
     folder: "src/content/pages"
     extension: mdx
+    format: frontmatter
     delete: false
     show_preview_links: false
     fields:

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -13,5 +13,6 @@
       integrity="sha384-RjpoGRpUGg1p+ypJVafvVW4tqDM8iiKI8V9znLHZh8h/wjNflwvVrUENSW38fLCO"
       crossorigin="anonymous"
     ></script>
+    <script src="cms.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- allow editing custom `ImageTextBlock` in Decap
- add missing `format` property for pages collection
- add registration script for the custom block

## Testing
- `npm run lint` *(fails: ESLint couldn't find an `eslint.config.js` file)*
- `npm run build` *(fails: `EnvInvalidVariables` about missing OAuth variables)*

------
https://chatgpt.com/codex/tasks/task_e_6869fecc6f3c8332a9754990cde35e46