### PR TITLE
Add CSP headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://avatars.githubusercontent.com; connect-src 'self' https://api.github.com https://github.com"
+        },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "same-origin" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Vercel headers with a Content Security Policy

## Testing
- `pnpm install`
- `npm run lint`
- `npm run build` *(fails: OAUTH_GITHUB_CLIENT_ID is missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b257180348332b72bf3beb919f8c3