### PR TITLE
Fix remark warnings for custom CMS block

### DIFF
--- a/public/admin/cms.js
+++ b/public/admin/cms.js
@@ -4,20 +4,26 @@ CMS.registerEditorComponent({
   label: "Image + Text",
   fields: [
     { name: "src", label: "Image", widget: "image" },
-    { name: "alt", label: "Image Alt", widget: "string" },
+    {
+      name: "alt",
+      label: "Image Alt",
+      widget: "string",
+      required: false,
+    },
     { name: "content", label: "Text", widget: "markdown" },
   ],
   pattern:
-    /^<ImageTextBlock[^>]*src="([^"]+)"[^>]*alt="([^"]*)"[^>]*>([\s\S]*?)<\/ImageTextBlock>$/ms,
+    /^<ImageTextBlock[^>]*src="([^"]+)"(?:[^>]*alt="([^"]*)")?[^>]*>([\s\S]*?)<\/ImageTextBlock>$/ms,
   fromBlock: function (match) {
     return {
       src: match[1],
-      alt: match[2],
+      alt: match[2] || "",
       content: match[3].trim(),
     };
   },
   toBlock: function (obj) {
-    return `<ImageTextBlock src="${obj.src}" alt="${obj.alt}">\n${obj.content}\n</ImageTextBlock>`;
+    const alt = obj.alt && obj.alt.trim() ? obj.alt : "image";
+    return `<ImageTextBlock src="${obj.src}" alt="${alt}">\n${obj.content}\n</ImageTextBlock>`;
   },
   toPreview: function (obj) {
     return `\n<div class="flex flex-col md:flex-row items-center gap-4">\n  <img src="${obj.src}" alt="${obj.alt}" style="width:48%" />\n  <div style="width:48%">${obj.content}</div>\n</div>`;


### PR DESCRIPTION
## Summary
- allow missing alt text when parsing ImageTextBlock
- provide default alt text of `"image"` if empty

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686b2df7ee688332a641f71c472b4185