### PR TITLE
Fix CMS regex for image-text-block

### DIFF
--- a/public/admin/cms.js
+++ b/public/admin/cms.js
@@ -13,7 +13,7 @@ CMS.registerEditorComponent({
     { name: "content", label: "Text", widget: "markdown" },
   ],
   pattern:
-    /^<ImageTextBlock[^>]*src="([^"]+)"(?:[^>]*alt="([^"]*)")?[^>]*>([\s\S]*?)<\/ImageTextBlock>$/ms,
+    /<ImageTextBlock[^>]*src="([^"]+)"(?:[^>]*alt="([^"]*)")?[^>]*>([\s\S]*?)<\/ImageTextBlock>/ms,
   fromBlock: function (match) {
     return {
       src: match[1],


### PR DESCRIPTION
## Summary
- fix regex so Decap CMS can parse ImageTextBlock anywhere in page content

## Testing
- `pnpm run lint`
- `pnpm run build` *(fails: EnvInvalidVariables)*

------
https://chatgpt.com/codex/tasks/task_e_686b3088f69c8332a9e6def11dc401f9