### PR TITLE
Fix image-text block parsing

### DIFF
--- a/public/admin/cms.js
+++ b/public/admin/cms.js
@@ -19,15 +19,16 @@ CMS.registerEditorComponent({
       src: match[1],
       alt: match[2] || "",
       content: match[3].trim(),
-    };
+    }
   },
   toBlock: function (obj) {
-    const alt = obj.alt && obj.alt.trim() ? obj.alt : "image";
-    return `<ImageTextBlock src="${obj.src}" alt="${alt}">\n${obj.content}\n</ImageTextBlock>`;
+    const altText = obj.alt && obj.alt.trim() ? obj.alt : "image"
+    const safeAlt = altText.replace(/"/g, '\\"')
+    return `<ImageTextBlock src="${obj.src}" alt="${safeAlt}">\n${obj.content}\n</ImageTextBlock>`
   },
   toPreview: function (obj) {
-    return `\n<div class="flex flex-col md:flex-row items-center gap-4">\n  <img src="${obj.src}" alt="${obj.alt}" style="width:48%" />\n  <div style="width:48%">${obj.content}</div>\n</div>`;
+    return `\n<div class="flex flex-col md:flex-row items-center gap-4">\n  <img src="${obj.src}" alt="${obj.alt}" style="width:48%" />\n  <div style="width:48%">${obj.content}</div>\n</div>`
   },
-});
+})
 
-CMS.init();
+CMS.init()

--- a/src/content/pages/home.mdx
+++ b/src/content/pages/home.mdx
@@ -2,10 +2,12 @@
 title: Home
 description: Welcome to Fog City Jazz
 ---
+
 # Welcome to **Fog City Jazz**.
 
 <ImageTextBlock src="/media/jeffrey.webp" alt="Cool Breeze himself">
-Welcome to the site! This block shows how you can mix images with text using a reusable component. Very cool.
+  Welcome to the site! This block shows how you can mix images with text using a
+  reusable component. Very cool.
 </ImageTextBlock>
 
 Homepage under construction! Please come back soon.


### PR DESCRIPTION
## Summary
- fix newline at end of `home.mdx`
- escape double quotes in CMS `ImageTextBlock` component

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686b3088f69c8332a9e6def11dc401f9