### PR TITLE
Add orientation and sizing options to ImageTextBlock

### DIFF
--- a/src/components/ImageTextBlock.astro
+++ b/src/components/ImageTextBlock.astro
@@ -1,10 +1,31 @@
 ---
-const { src, alt } = Astro.props
+const {
+  src,
+  alt,
+  imageWidth = 50,
+  imageOnLeft = true,
+  topAlign = false,
+} = Astro.props
+const textWidth = 100 - imageWidth
 ---
 
-<div class="flex flex-col md:flex-row items-center gap-4">
-  <img src={src} alt={alt} class="md:w-1/2 w-full" />
-  <div class="md:w-1/2 w-full">
+<div
+  class={`image-text-block flex flex-col md:flex-row gap-4 w-full ${topAlign ? "items-start" : "items-center"} ${imageOnLeft ? "" : "md:flex-row-reverse"}`}
+  style={`--image-width:${imageWidth}%; --text-width:${textWidth}%`}
+>
+  <img src={src} alt={alt} class="rounded w-full" />
+  <div class="w-full">
     <slot />
   </div>
 </div>
+
+<style>
+  @media (min-width: 768px) {
+    .image-text-block > img {
+      width: var(--image-width);
+    }
+    .image-text-block > div {
+      width: var(--text-width);
+    }
+  }
+</style>

--- a/src/content/pages/home.mdx
+++ b/src/content/pages/home.mdx
@@ -4,7 +4,13 @@ description: Welcome to Fog City Jazz
 ---
 # Welcome to **Fog City Jazz**.
 
-<ImageTextBlock src="/media/fogcity.webp" alt="Cool Breeze himself">
+<ImageTextBlock
+  src="/media/fogcity.webp"
+  alt="Cool Breeze himself"
+  imageWidth={40}
+  imageOnLeft={false}
+  topAlign={false}
+>
 Welcome to the site! This is a website for Fog City Jazz, aka Jeffrey Gaeto in San Francisco.
 </ImageTextBlock>
 


### PR DESCRIPTION
## Summary
- allow placing image on left or right
- let the image width be customized
- control text vertical alignment
- round image corners and make the block always full-width
- update home page example
- extend Decap CMS editor for new props

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872a841af2483329ef4dfd8a922edea