### PR TITLE
Add SoundCloud embed component

### DIFF
--- a/public/admin/cms.js
+++ b/public/admin/cms.js
@@ -19,15 +19,50 @@ CMS.registerEditorComponent({
       src: match[1],
       alt: match[2] || "",
       content: match[3].trim(),
-    };
+    }
   },
   toBlock: function (obj) {
-    const alt = obj.alt && obj.alt.trim() ? obj.alt : "image";
-    return `<ImageTextBlock src="${obj.src}" alt="${alt}">\n${obj.content}\n</ImageTextBlock>`;
+    const alt = obj.alt && obj.alt.trim() ? obj.alt : "image"
+    return `<ImageTextBlock src="${obj.src}" alt="${alt}">\n${obj.content}\n</ImageTextBlock>`
   },
   toPreview: function (obj) {
-    return `\n<div class="flex flex-col md:flex-row items-center gap-4">\n  <img src="${obj.src}" alt="${obj.alt}" style="width:48%" />\n  <div style="width:48%">${obj.content}</div>\n</div>`;
+    return `\n<div class="flex flex-col md:flex-row items-center gap-4">\n  <img src="${obj.src}" alt="${obj.alt}" style="width:48%" />\n  <div style="width:48%">${obj.content}</div>\n</div>`
   },
-});
+})
 
-CMS.init();
+CMS.registerEditorComponent({
+  id: "soundcloud-embed",
+  label: "SoundCloud",
+  fields: [
+    { name: "iframe", label: "Iframe", widget: "text" },
+    { name: "title", label: "Title", widget: "string" },
+    {
+      name: "description",
+      label: "Description",
+      widget: "string",
+      required: false,
+    },
+  ],
+  pattern:
+    /^<SoundcloudEmbed[^>]*iframe='([^']+)'[^>]*title="([^"]+)"(?:[^>]*description="([^"]*)")?\s*\/>$/ms,
+  fromBlock: function (match) {
+    return {
+      iframe: match[1],
+      title: match[2],
+      description: match[3] || "",
+    }
+  },
+  toBlock: function (obj) {
+    const desc =
+      obj.description && obj.description.trim()
+        ? ` description="${obj.description}"`
+        : ""
+    return `<SoundcloudEmbed iframe='${obj.iframe}' title="${obj.title}"${desc} />`
+  },
+  toPreview: function (obj) {
+    const desc = obj.description ? `<p>${obj.description}</p>` : ""
+    return `<div><strong>${obj.title}</strong>${desc}${obj.iframe}</div>`
+  },
+})
+
+CMS.init()

--- a/src/components/SoundcloudEmbed.astro
+++ b/src/components/SoundcloudEmbed.astro
@@ -1,0 +1,9 @@
+---
+const { iframe, title, description } = Astro.props
+---
+
+<div class="my-4">
+  <h3 class="text-xl font-bold mb-2">{title}</h3>
+  {description && <p class="mb-4">{description}</p>}
+  <div class="w-full" set:html={iframe} />
+</div>

--- a/src/content/pages/music.mdx
+++ b/src/content/pages/music.mdx
@@ -4,3 +4,9 @@ description: Listen to our recordings
 ---
 
 Compositions and live recordings coming soon.
+
+<SoundcloudEmbed
+  title="Demo Track"
+  description="Listen to a sample recording."
+  iframe='<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/12345"></iframe>'
+/>

--- a/src/pages/music.astro
+++ b/src/pages/music.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../layouts/BaseLayout.astro"
 import { getEntryBySlug } from "astro:content"
 import ImageTextBlock from "../components/ImageTextBlock.astro"
+import SoundcloudEmbed from "../components/SoundcloudEmbed.astro"
 
 const entry = await getEntryBySlug("pages", "music")
 const { Content } = await entry.render()
@@ -12,5 +13,5 @@ const { Content } = await entry.render()
   description={entry.data.description}
   sideBarActiveItemID="music"
 >
-  <Content components={{ ImageTextBlock }} />
+  <Content components={{ ImageTextBlock, SoundcloudEmbed }} />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- add new `SoundcloudEmbed` component
- register the component in Decap's `cms.js`
- allow music page to use the new component
- demo SoundCloud embed in `music.mdx`

## Testing
- `pnpm run lint`
- `pnpm run build` *(fails: EnvInvalidVariables)*

------
https://chatgpt.com/codex/tasks/task_e_6872abfe729c83329ee0fce9323df773