### PR TITLE
Fix SoundCloudEmbed across MDX pages

### DIFF
--- a/src/components/mdx-components.ts
+++ b/src/components/mdx-components.ts
@@ -1,0 +1,9 @@
+import ImageTextBlock from './ImageTextBlock.astro';
+import SoundCloudEmbed from './SoundCloudEmbed.astro';
+
+export const mdxComponents = {
+  ImageTextBlock,
+  SoundCloudEmbed,
+};
+
+export default mdxComponents;

--- a/src/pages/bio.astro
+++ b/src/pages/bio.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro"
 import { getEntryBySlug } from "astro:content"
-import ImageTextBlock from "../components/ImageTextBlock.astro"
+import mdxComponents from "../components/mdx-components"
 
 const entry = await getEntryBySlug("pages", "bio")
 const { Content } = await entry.render()
@@ -12,5 +12,5 @@ const { Content } = await entry.render()
   description={entry.data.description}
   sideBarActiveItemID="bio"
 >
-  <Content components={{ ImageTextBlock }} />
+  <Content components={mdxComponents} />
 </BaseLayout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro"
 import { getEntryBySlug } from "astro:content"
-import ImageTextBlock from "../components/ImageTextBlock.astro"
+import mdxComponents from "../components/mdx-components"
 
 const entry = await getEntryBySlug("pages", "contact")
 const { Content } = await entry.render()
@@ -12,5 +12,5 @@ const { Content } = await entry.render()
   description={entry.data.description}
   sideBarActiveItemID="contact"
 >
-  <Content components={{ ImageTextBlock }} />
+  <Content components={mdxComponents} />
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro"
 import { getEntryBySlug } from "astro:content"
-import ImageTextBlock from "../components/ImageTextBlock.astro"
+import mdxComponents from "../components/mdx-components"
 
 const entry = await getEntryBySlug("pages", "home")
 const { Content } = await entry.render()
@@ -12,5 +12,5 @@ const { Content } = await entry.render()
   description={entry.data.description}
   sideBarActiveItemID="home"
 >
-  <Content components={{ ImageTextBlock }} />
+  <Content components={mdxComponents} />
 </BaseLayout>

--- a/src/pages/lessons.astro
+++ b/src/pages/lessons.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro"
 import { getEntryBySlug } from "astro:content"
-import ImageTextBlock from "../components/ImageTextBlock.astro"
+import mdxComponents from "../components/mdx-components"
 
 const entry = await getEntryBySlug("pages", "lessons")
 const { Content } = await entry.render()
@@ -12,5 +12,5 @@ const { Content } = await entry.render()
   description={entry.data.description}
   sideBarActiveItemID="lessons"
 >
-  <Content components={{ ImageTextBlock }} />
+  <Content components={mdxComponents} />
 </BaseLayout>

--- a/src/pages/music.astro
+++ b/src/pages/music.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro"
 import { getEntryBySlug } from "astro:content"
-import ImageTextBlock from "../components/ImageTextBlock.astro"
+import mdxComponents from "../components/mdx-components"
 
 const entry = await getEntryBySlug("pages", "music")
 const { Content } = await entry.render()
@@ -12,5 +12,5 @@ const { Content } = await entry.render()
   description={entry.data.description}
   sideBarActiveItemID="music"
 >
-  <Content components={{ ImageTextBlock }} />
+  <Content components={mdxComponents} />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- bundle common MDX components in one place
- use new component collection when rendering pages

## Testing
- `pnpm lint`
- `pnpm build` *(fails: OAUTH_GITHUB_CLIENT_ID missing)*

------
https://chatgpt.com/codex/tasks/task_e_6872bb84f008833281fb4ebac3f18a5a