### PR TITLE
Fix SoundCloud iframe CSP

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://vercel.live; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://avatars.githubusercontent.com; connect-src 'self' https://api.github.com https://github.com"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://vercel.live; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://avatars.githubusercontent.com; connect-src 'self' https://api.github.com https://github.com; frame-src 'self' https://w.soundcloud.com"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "same-origin" }


### PR DESCRIPTION
## Summary
- allow `w.soundcloud.com` in the Content Security Policy's `frame-src`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872bd1cf8f8833288b57f33bd996dd0