### PR TITLE
Add Google Fonts

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,7 +19,7 @@
       </label>
     </div>
     <div class="navbar-center">
-      <a class="btn btn-ghost normal-case text-xl" href="/">Fog City Jazz</a>
+      <a class="btn btn-ghost normal-case text-xl font-display" href="/">Fog City Jazz</a>
     </div>
     <div class="navbar-end"></div>
   </div>

--- a/src/components/SideBar.astro
+++ b/src/components/SideBar.astro
@@ -24,7 +24,7 @@ const { sideBarActiveItemID } = Astro.props
             />
           </div>
         </div>
-        <div class="font-bold text-base-content text-xl">Fog City Jazz</div>
+        <div class="font-bold text-base-content text-xl font-display">Fog City Jazz</div>
       </a>
     </div>
     <SideBarMenu sideBarActiveItemID={sideBarActiveItemID} />

--- a/src/components/SideBarFooter.astro
+++ b/src/components/SideBarFooter.astro
@@ -3,5 +3,5 @@ const today = new Date()
 ---
 
 <footer class="footer footer-center block mb-5 pt-10 text-base-content/40">
-  <div class="pb-2">&copy; {today.getFullYear()} Fog City Jazz</div>
+  <div class="pb-2 font-display">&copy; {today.getFullYear()} Fog City Jazz</div>
 </footer>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
+@import url('https://fonts.googleapis.com/css2?family=Abril+Fatface&family=Droid+Sans:wght@400;700&display=swap');
+
+@layer base {
+  body {
+    @apply font-sans;
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-display;
+  }
+}
+
 .time-line-container > div:last-child .education__time > .education__line {
   display: none;
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,8 +1,15 @@
 /** @type {import('tailwindcss').Config} */
+const defaultTheme = require("tailwindcss/defaultTheme")
+
 module.exports = {
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ["'Droid Sans'", ...defaultTheme.fontFamily.sans],
+        display: ["'Abril Fatface'", "cursive"],
+      },
+    },
   },
   plugins: [require("@tailwindcss/typography"), require("daisyui")],
   daisyui: {


### PR DESCRIPTION
## Summary
- add Abril Fatface and Droid Sans fonts via Tailwind config
- apply new font families through global base styles
- style site title elements with the display font

## Testing
- `pnpm lint`
- `pnpm build` *(fails: OAUTH_GITHUB_CLIENT_ID and OAUTH_GITHUB_CLIENT_SECRET missing)*

------
https://chatgpt.com/codex/tasks/task_e_6872c06479fc833285eb150d7de0571f