### PR TITLE
Add hero component with Decap frontmatter

### DIFF
--- a/decap.config.ts
+++ b/decap.config.ts
@@ -1,0 +1,43 @@
+export default defineDecapConfig({
+  collections: {
+    pages: {
+      label: "Pages",
+      path: "src/content/pages",
+      frontmatter: {
+        schema: {
+          hero: {
+            type: "object",
+            label: "Hero Section",
+            fields: {
+              image: {
+                type: "image",
+                label: "Background Image",
+                required: true,
+              },
+              video: { type: "string", label: "Background Video (optional)" },
+              title: { type: "string", label: "Title", required: true },
+              subtitle: { type: "string", label: "Subtitle", required: true },
+              cta: {
+                type: "object",
+                label: "CTA Button",
+                fields: {
+                  text: {
+                    type: "string",
+                    label: "Button Text",
+                    required: true,
+                  },
+                  href: { type: "string", label: "Link HREF", required: true },
+                  primary: {
+                    type: "boolean",
+                    label: "Solid Button?",
+                    default: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+})

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,0 +1,59 @@
+---
+// no props — pull from frontmatter
+const { image, video, title, subtitle, cta } = Astro.props.frontmatter.hero
+---
+
+<div
+  class="relative overflow-hidden rounded-xl h-[60vh] sm:h-[70vh] lg:h-[80vh]"
+>
+  {
+    video ? (
+      <video
+        src={video}
+        poster={image}
+        autoplay
+        muted
+        loop
+        playsinline
+        aria-hidden="true"
+        class="absolute inset-0 w-full h-full object-cover"
+      />
+    ) : (
+      <img
+        src={image}
+        alt=""
+        loading="lazy"
+        class="absolute inset-0 w-full h-full object-cover"
+      />
+    )
+  }
+
+  <div
+    class="relative z-10 w-full h-full bg-gradient-to-b from-transparent to-black/40 p-4 sm:p-6 lg:p-8 flex flex-col justify-between"
+  >
+    <!-- Top-left text -->
+    <div class="max-w-lg">
+      <h1
+        class="font-display text-3xl sm:text-5xl lg:text-6xl text-white drop-shadow-md"
+      >
+        {title}
+      </h1>
+      <p class="mt-2 text-lg sm:text-xl text-white/90 drop-shadow-sm">
+        {subtitle}
+      </p>
+    </div>
+
+    <!-- Bottom-right CTA -->
+    <div class="self-end">
+      <a
+        href={cta.href}
+        class={`inline-block py-3 px-6 rounded-lg font-medium transition ` +
+          (cta.primary
+            ? `bg-gold text-black hover:bg-gold-dark`
+            : `border border-gold text-white hover:bg-gold/20`)}
+      >
+        {cta.text}
+      </a>
+    </div>
+  </div>
+</div>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,8 +1,23 @@
 import { z, defineCollection } from "astro:content"
 
+const ctaSchema = z.object({
+  text: z.string(),
+  href: z.string(),
+  primary: z.boolean().optional(),
+})
+
+const heroSchema = z.object({
+  image: z.string(),
+  video: z.string().nullable().optional(),
+  title: z.string(),
+  subtitle: z.string().optional(),
+  cta: ctaSchema,
+})
+
 const pageSchema = z.object({
   title: z.string(),
   description: z.string().optional(),
+  hero: heroSchema.optional(),
 })
 
 export type PageSchema = z.infer<typeof pageSchema>

--- a/src/content/pages/bio.mdx
+++ b/src/content/pages/bio.mdx
@@ -1,6 +1,15 @@
 ---
 title: Bio
 description: Learn more about Fog City Jazz
+hero:
+  image: "/media/fogcity.webp"
+  video: null
+  title: "About Fog City Jazz"
+  subtitle: "Jeffrey Gaeto in San Francisco"
+  cta:
+    text: "Reach Out"
+    href: "/contact"
+    primary: true
 ---
 
 Jeffrey Gaeto!

--- a/src/content/pages/contact.mdx
+++ b/src/content/pages/contact.mdx
@@ -1,6 +1,15 @@
 ---
 title: Contact
 description: Get in touch with us
+hero:
+  image: "/media/fogcity.webp"
+  video: null
+  title: "Get in Touch"
+  subtitle: "Let's talk music"
+  cta:
+    text: "Email Us"
+    href: "/contact"
+    primary: true
 ---
 
 Jeffrey Gaeto

--- a/src/content/pages/home.mdx
+++ b/src/content/pages/home.mdx
@@ -1,6 +1,15 @@
 ---
 title: Home
 description: Welcome to Fog City Jazz
+hero:
+  image: "/media/fogcity.webp"
+  video: null
+  title: "Fog City Jazz"
+  subtitle: "Music & lessons in San Francisco"
+  cta:
+    text: "Contact"
+    href: "/contact"
+    primary: true
 ---
 # Welcome to **Fog City Jazz**.
 

--- a/src/content/pages/lessons.mdx
+++ b/src/content/pages/lessons.mdx
@@ -1,6 +1,15 @@
 ---
 title: Lessons
 description: Private and group instruction
+hero:
+  image: "/media/fogcity.webp"
+  video: null
+  title: "Private & Group Lessons"
+  subtitle: "Learn to play jazz"
+  cta:
+    text: "Sign Up"
+    href: "/contact"
+    primary: true
 ---
 
 Lessons are available.

--- a/src/content/pages/music.mdx
+++ b/src/content/pages/music.mdx
@@ -1,6 +1,15 @@
 ---
 title: Music
 description: Listen to our recordings
+hero:
+  image: "/media/fogcity.webp"
+  video: null
+  title: "Our Music"
+  subtitle: "Listen to recordings"
+  cta:
+    text: "Hear More"
+    href: "/music"
+    primary: true
 ---
 Compositions and live recordings coming soon.
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,10 +4,12 @@ import BaseHead from "../components/BaseHead.astro"
 import Footer from "../components/Footer.astro"
 import Header from "../components/Header.astro"
 import SideBar from "../components/SideBar.astro"
+import Hero from "../components/Hero.astro"
 
 import { SITE_DESCRIPTION, SITE_TITLE, TRANSITION_API } from "../config"
 
 const {
+  frontmatter,
   image,
   title = SITE_TITLE,
   description = SITE_DESCRIPTION,
@@ -34,6 +36,7 @@ const {
       <input id="my-drawer" type="checkbox" class="drawer-toggle" />
       <div class="drawer-content bg-base-100">
         <Header title={SITE_TITLE} />
+        {frontmatter?.hero && <Hero frontmatter={frontmatter} />}
         <div class="md:flex md:justify-center">
           <main class="p-6 pt-10 lg:max-w-[900px] max-w-[100vw] w-full h-full">
             {

--- a/src/pages/bio.astro
+++ b/src/pages/bio.astro
@@ -7,10 +7,6 @@ const entry = await getEntryBySlug("pages", "bio")
 const { Content } = await entry.render()
 ---
 
-<BaseLayout
-  title={entry.data.title}
-  description={entry.data.description}
-  sideBarActiveItemID="bio"
->
+<BaseLayout {...entry.data} frontmatter={entry.data} sideBarActiveItemID="bio">
   <Content components={mdxComponents} />
 </BaseLayout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -8,8 +8,8 @@ const { Content } = await entry.render()
 ---
 
 <BaseLayout
-  title={entry.data.title}
-  description={entry.data.description}
+  {...entry.data}
+  frontmatter={entry.data}
   sideBarActiveItemID="contact"
 >
   <Content components={mdxComponents} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,10 +7,6 @@ const entry = await getEntryBySlug("pages", "home")
 const { Content } = await entry.render()
 ---
 
-<BaseLayout
-  title={entry.data.title}
-  description={entry.data.description}
-  sideBarActiveItemID="home"
->
+<BaseLayout {...entry.data} frontmatter={entry.data} sideBarActiveItemID="home">
   <Content components={mdxComponents} />
 </BaseLayout>

--- a/src/pages/lessons.astro
+++ b/src/pages/lessons.astro
@@ -8,8 +8,8 @@ const { Content } = await entry.render()
 ---
 
 <BaseLayout
-  title={entry.data.title}
-  description={entry.data.description}
+  {...entry.data}
+  frontmatter={entry.data}
   sideBarActiveItemID="lessons"
 >
   <Content components={mdxComponents} />

--- a/src/pages/music.astro
+++ b/src/pages/music.astro
@@ -8,8 +8,8 @@ const { Content } = await entry.render()
 ---
 
 <BaseLayout
-  title={entry.data.title}
-  description={entry.data.description}
+  {...entry.data}
+  frontmatter={entry.data}
   sideBarActiveItemID="music"
 >
   <Content components={mdxComponents} />


### PR DESCRIPTION
## Summary
- add `Hero.astro` component to render hero section
- integrate hero rendering in `BaseLayout`
- expose hero schema in `content/config.ts`
- add Decap collection configuration
- update Astro pages to pass frontmatter to layout
- add hero data to each page's frontmatter

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6876953d76b48332bc3fe32a230c734e