### PR TITLE
Fix SoundCloud Embed editor

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -28,4 +28,9 @@ collections:
           widget: "string",
           required: false,
         }
-      - { label: Body, name: body, widget: "markdown" }
+      - label: Body
+        name: body
+        widget: markdown
+        editor_components:
+          - image-text-block
+          - soundcloud-embed


### PR DESCRIPTION
## Summary
- enable the custom SoundCloud embed component in Decap CMS

## Testing
- `npm run build` *(fails: missing OAUTH env vars)*

------
https://chatgpt.com/codex/tasks/task_e_6879517ecf208332b9f206069e5e5e3c