### PR TITLE
Improve hero spacing and CTA styling

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -4,7 +4,7 @@ const { image, video, title, subtitle, cta } = Astro.props.frontmatter.hero
 ---
 
 <div
-  class="relative overflow-hidden rounded-xl h-[60vh] sm:h-[70vh] lg:h-[80vh]"
+  class="relative overflow-hidden rounded-xl h-[60vh] sm:h-[70vh] lg:h-[80vh] max-h-[600px]"
 >
   {
     video ? (

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -47,10 +47,7 @@ const { image, video, title, subtitle, cta } = Astro.props.frontmatter.hero
     <div class="self-end">
       <a
         href={cta.href}
-        class={`inline-block py-3 px-6 rounded-lg font-medium transition ` +
-          (cta.primary
-            ? `bg-gold text-black hover:bg-gold-dark`
-            : `border border-gold text-white hover:bg-gold/20`)}
+        class="inline-block py-3 px-6 rounded-lg font-medium bg-white text-black shadow-md transition transform hover:shadow-xl hover:scale-105"
       >
         {cta.text}
       </a>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -36,7 +36,13 @@ const {
       <input id="my-drawer" type="checkbox" class="drawer-toggle" />
       <div class="drawer-content bg-base-100">
         <Header title={SITE_TITLE} />
-        {frontmatter?.hero && <Hero frontmatter={frontmatter} />}
+        {frontmatter?.hero && (
+          <div class="md:flex md:justify-center">
+            <div class="px-6 w-full lg:max-w-[900px]">
+              <Hero frontmatter={frontmatter} />
+            </div>
+          </div>
+        )}
         <div class="md:flex md:justify-center">
           <main class="p-6 pt-10 lg:max-w-[900px] max-w-[100vw] w-full h-full">
             {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -37,7 +37,7 @@ const {
       <div class="drawer-content bg-base-100">
         <Header title={SITE_TITLE} />
         {frontmatter?.hero && (
-          <div class="md:flex md:justify-center">
+          <div class="md:flex md:justify-center mt-6">
             <div class="px-6 w-full lg:max-w-[900px]">
               <Hero frontmatter={frontmatter} />
             </div>


### PR DESCRIPTION
## Summary
- inset Hero component to align with page text container
- restyle hero CTA with white background and hover effects

## Testing
- `npm run lint`
- `npm run build` *(fails: OAUTH_GITHUB_CLIENT_ID, OAUTH_GITHUB_CLIENT_SECRET missing)*

------
https://chatgpt.com/codex/tasks/task_e_687950e6b8e88332bb9910af827e4343