### PR TITLE
Fix SoundCloud component detection in Decap

### DIFF
--- a/public/admin/cms.js
+++ b/public/admin/cms.js
@@ -80,7 +80,9 @@ CMS.registerEditorComponent({
     },
     { name: "iframe", label: "Embed Code", widget: "text" },
   ],
-  pattern: /^<SoundCloudEmbed([^>]*)\/>$/ms,
+  // Allow any characters (including ">" from the iframe HTML) in the attribute
+  // string so the component is correctly detected by Decap.
+  pattern: /^<SoundCloudEmbed([\s\S]*?)\/>$/ms,
   fromBlock: function (match) {
     const attrs = match[1]
     const get = (regex, d) => {


### PR DESCRIPTION
## Summary
- update regex for SoundCloudEmbed editor component so attributes containing `>` characters are handled properly

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6879551c132c8332bb421803f0e404ee