### PR TITLE
Expose hero fields in page frontmatter

### DIFF
--- a/decap.config.ts
+++ b/decap.config.ts
@@ -5,9 +5,14 @@ export default defineDecapConfig({
       path: "src/content/pages",
       frontmatter: {
         schema: {
+          title: { type: "string", label: "Title", required: true },
+          heroTitle: { type: "string", label: "Hero Title", required: true },
+          description: { type: "string", label: "Description" },
+          ctaText: { type: "string", label: "CTA Text" },
+          ctaLink: { type: "string", label: "CTA Link" },
           hero: {
             type: "object",
-            label: "Hero Section",
+            label: "Hero Media",
             fields: {
               image: {
                 type: "image",
@@ -15,25 +20,6 @@ export default defineDecapConfig({
                 required: true,
               },
               video: { type: "string", label: "Background Video (optional)" },
-              title: { type: "string", label: "Title", required: true },
-              subtitle: { type: "string", label: "Subtitle", required: true },
-              cta: {
-                type: "object",
-                label: "CTA Button",
-                fields: {
-                  text: {
-                    type: "string",
-                    label: "Button Text",
-                    required: true,
-                  },
-                  href: { type: "string", label: "Link HREF", required: true },
-                  primary: {
-                    type: "boolean",
-                    label: "Solid Button?",
-                    default: true,
-                  },
-                },
-              },
             },
           },
         },

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,6 +1,13 @@
 ---
-// no props — pull from frontmatter
-const { image, video, title, subtitle, cta } = Astro.props.frontmatter.hero
+// pull hero data from frontmatter with backwards compatibility for old fields
+const frontmatter = Astro.props.frontmatter
+const hero = frontmatter.hero ?? {}
+const { image, video } = hero
+
+const title = frontmatter.heroTitle ?? hero.title
+const subtitle = frontmatter.description ?? hero.subtitle
+const ctaText = frontmatter.ctaText ?? hero?.cta?.text
+const ctaLink = frontmatter.ctaLink ?? hero?.cta?.href
 ---
 
 <div
@@ -46,10 +53,10 @@ const { image, video, title, subtitle, cta } = Astro.props.frontmatter.hero
     <!-- Bottom-right CTA -->
     <div class="self-end">
       <a
-        href={cta.href}
+        href={ctaLink}
         class="inline-block py-3 px-6 rounded-lg font-medium bg-white text-black shadow-md transition transform hover:shadow-xl hover:scale-105"
       >
-        {cta.text}
+        {ctaText}
       </a>
     </div>
   </div>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,22 +1,16 @@
 import { z, defineCollection } from "astro:content"
 
-const ctaSchema = z.object({
-  text: z.string(),
-  href: z.string(),
-  primary: z.boolean().optional(),
-})
-
 const heroSchema = z.object({
   image: z.string(),
   video: z.string().nullable().optional(),
-  title: z.string(),
-  subtitle: z.string().optional(),
-  cta: ctaSchema,
 })
 
 const pageSchema = z.object({
   title: z.string(),
+  heroTitle: z.string().optional(),
   description: z.string().optional(),
+  ctaText: z.string().optional(),
+  ctaLink: z.string().optional(),
   hero: heroSchema.optional(),
 })
 

--- a/src/content/pages/bio.mdx
+++ b/src/content/pages/bio.mdx
@@ -1,15 +1,12 @@
 ---
 title: Bio
+heroTitle: About Fog City Jazz
 description: Learn more about Fog City Jazz
+ctaText: Reach Out
+ctaLink: /contact
 hero:
   image: "/media/fogcity.webp"
   video: null
-  title: "About Fog City Jazz"
-  subtitle: "Jeffrey Gaeto in San Francisco"
-  cta:
-    text: "Reach Out"
-    href: "/contact"
-    primary: true
 ---
 
 Jeffrey Gaeto!

--- a/src/content/pages/contact.mdx
+++ b/src/content/pages/contact.mdx
@@ -1,15 +1,12 @@
 ---
 title: Contact
+heroTitle: Get in Touch
 description: Get in touch with us
+ctaText: Email Us
+ctaLink: /contact
 hero:
   image: "/media/fogcity.webp"
   video: null
-  title: "Get in Touch"
-  subtitle: "Let's talk music"
-  cta:
-    text: "Email Us"
-    href: "/contact"
-    primary: true
 ---
 
 Jeffrey Gaeto

--- a/src/content/pages/home.mdx
+++ b/src/content/pages/home.mdx
@@ -1,20 +1,25 @@
 ---
 title: Home
+heroTitle: Fog City Jazz
 description: Welcome to Fog City Jazz
+ctaText: Contact
+ctaLink: /contact
 hero:
   image: "/media/fogcity.webp"
   video: null
-  title: "Fog City Jazz"
-  subtitle: "Music & lessons in San Francisco"
-  cta:
-    text: "Contact"
-    href: "/contact"
-    primary: true
 ---
+
 # Welcome to **Fog City Jazz**.
 
-<ImageTextBlock src="/media/fogcity.webp" alt="Cool Breeze himself" imageWidth={60} imageOnLeft={true} topAlign={true}>
-Welcome to the site! This is a website for Fog City Jazz, aka Jeffrey Gaeto in San Francisco. Enjoy the site!
+<ImageTextBlock
+  src="/media/fogcity.webp"
+  alt="Cool Breeze himself"
+  imageWidth={60}
+  imageOnLeft={true}
+  topAlign={true}
+>
+  Welcome to the site! This is a website for Fog City Jazz, aka Jeffrey Gaeto in
+  San Francisco. Enjoy the site!
 </ImageTextBlock>
 
 Homepage under construction! Please come back soon.

--- a/src/content/pages/lessons.mdx
+++ b/src/content/pages/lessons.mdx
@@ -1,15 +1,12 @@
 ---
 title: Lessons
+heroTitle: Private & Group Lessons
 description: Private and group instruction
+ctaText: Sign Up
+ctaLink: /contact
 hero:
   image: "/media/fogcity.webp"
   video: null
-  title: "Private & Group Lessons"
-  subtitle: "Learn to play jazz"
-  cta:
-    text: "Sign Up"
-    href: "/contact"
-    primary: true
 ---
 
 Lessons are available.

--- a/src/content/pages/music.mdx
+++ b/src/content/pages/music.mdx
@@ -1,16 +1,18 @@
 ---
 title: Music
+heroTitle: Our Music
 description: Listen to our recordings
+ctaText: Hear More
+ctaLink: /music
 hero:
   image: "/media/fogcity.webp"
   video: null
-  title: "Our Music"
-  subtitle: "Listen to recordings"
-  cta:
-    text: "Hear More"
-    href: "/music"
-    primary: true
 ---
+
 Compositions and live recordings coming soon.
 
-<SoundCloudEmbed title="SoundCloud test" description="This is a test of a soundcloud link, let's hope it works" iframe={`<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1442707219&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe><div style="font-size: 10px; color: #cccccc;line-break: anywhere;word-break: normal;overflow: hidden;white-space: nowrap;text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif;font-weight: 100;"><a href="https://soundcloud.com/jeffrey-gaeto" title="Jeffrey Gaeto" target="_blank" style="color: #cccccc; text-decoration: none;">Jeffrey Gaeto</a> · <a href="https://soundcloud.com/jeffrey-gaeto/waltz-on-wire-b5" title="Waltz On Wire B5" target="_blank" style="color: #cccccc; text-decoration: none;">Waltz On Wire B5</a></div>`} />
+<SoundCloudEmbed
+  title="SoundCloud test"
+  description="This is a test of a soundcloud link, let's hope it works"
+  iframe={`<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1442707219&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe><div style="font-size: 10px; color: #cccccc;line-break: anywhere;word-break: normal;overflow: hidden;white-space: nowrap;text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif;font-weight: 100;"><a href="https://soundcloud.com/jeffrey-gaeto" title="Jeffrey Gaeto" target="_blank" style="color: #cccccc; text-decoration: none;">Jeffrey Gaeto</a> · <a href="https://soundcloud.com/jeffrey-gaeto/waltz-on-wire-b5" title="Waltz On Wire B5" target="_blank" style="color: #cccccc; text-decoration: none;">Waltz On Wire B5</a></div>`}
+/>


### PR DESCRIPTION
## Summary
- add hero fields (`heroTitle`, `ctaText`, `ctaLink`) to Decap config
- adjust content schema for new fields
- update Hero component to read new fields
- update all page frontmatter to use new hero properties

## Testing
- `pnpm lint`
- `pnpm build` *(fails: EnvInvalidVariables)*

------
https://chatgpt.com/codex/tasks/task_e_68851cd77a30833292a6d4d299836f37