### PR TITLE
Enable hero fields in Decap CMS pages

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -20,17 +20,29 @@ collections:
     format: frontmatter
     delete: false
     show_preview_links: false
-    fields:
-      - { label: Title, name: title, widget: "string" }
-      - {
-          label: Description,
-          name: description,
-          widget: "string",
-          required: false,
-        }
-      - label: Body
-        name: body
-        widget: markdown
-        editor_components:
-          - image-text-block
+      fields:
+        - { label: Title, name: title, widget: "string" }
+        - { label: Hero Title, name: heroTitle, widget: "string" }
+        - {
+            label: Description,
+            name: description,
+            widget: "string",
+            required: false,
+          }
+        - label: Hero Media
+          name: hero
+          widget: object
+          fields:
+            - label: Background Image
+              name: image
+              widget: image
+              required: true
+            - { label: Background Video (optional), name: video, widget: string, required: false }
+        - { label: CTA Text, name: ctaText, widget: "string", required: false }
+        - { label: CTA Link, name: ctaLink, widget: "string", required: false }
+        - label: Body
+          name: body
+          widget: markdown
+          editor_components:
+            - image-text-block
           - soundcloud-embed


### PR DESCRIPTION
## Summary
- add hero field definitions to Decap config so pages can edit hero details in CMS

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6885219816708332b765c66ae84e47bc