### PR TITLE
Restore Decap CMS custom embed components

### DIFF
--- a/src/pages/admin/cms.ts
+++ b/src/pages/admin/cms.ts
@@ -1,6 +1,5 @@
-// currently unused
-
 /* eslint-disable @typescript-eslint/no-explicit-any */
+// Register custom Decap CMS editor components
 export default function setupCMS(CMS: any) {
   CMS.registerEditorComponent({
     // id uses kebab-case per Decap docs

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -4,7 +4,7 @@
 <!doctype html>
 <html>
   <head>
-    <meta charSet="utf-8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />
     <title>Fog City Jazz CMS</title>
@@ -13,103 +13,12 @@
     <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
   </head>
   <body>
-    <script>
-      // Access the global CMS object from the CDN script
+    <script type="module">
+      import setupCMS from './cms';
       // @ts-expect-error - CMS is loaded globally from the CDN script
       const CMS = window.CMS;
-      
-      // Setup the CMS with custom components
-      CMS.registerEditorComponent({
-        // id uses kebab-case per Decap docs
-        id: 'image-text-block',
-        label: 'Image + Text',
-        fields: [
-          { name: 'src', label: 'Image', widget: 'image' },
-          { name: 'alt', label: 'Image Alt', widget: 'string', required: false },
-          { name: 'imageWidth', label: 'Image Width (%)', widget: 'number', default: 50 },
-          { name: 'imageOnLeft', label: 'Image on Left', widget: 'boolean', default: true },
-          { name: 'topAlign', label: 'Top Align Text', widget: 'boolean', default: false },
-          { name: 'content', label: 'Text', widget: 'markdown' },
-        ],
-        pattern: /^<ImageTextBlock([^>]*)>([\s\S]*?)<\/ImageTextBlock>$/ms,
-        fromBlock: function (match) {
-          const attrs = match[1]
-          const get = (regex, d) => {
-            const m = attrs.match(regex)
-            return m ? m[1] : d
-          }
-          const src = get(/src="([^"]+)"/, '')
-          const alt = get(/alt="([^"]*)"/, '')
-          const imageWidth = parseInt(get(/imageWidth=["{]?([^"]+)["}]?/, '50'), 10)
-          const imageOnLeft = get(/imageOnLeft=["{]?([^"]+)["}]?/, 'true') === 'true'
-          const topAlign = get(/topAlign=["{]?([^"]+)["}]?/, 'false') === 'false'
-          return {
-            src,
-            alt,
-            imageWidth,
-            imageOnLeft,
-            topAlign,
-            content: match[2].trim(),
-          }
-        },
-        toBlock: function (obj) {
-          const alt = obj.alt && obj.alt.trim() ? obj.alt : 'image'
-          const width = obj.imageWidth ?? 50
-          const left = obj.imageOnLeft ?? true
-          const top = obj.topAlign ?? false
-          return `<ImageTextBlock src="${obj.src}" alt="${alt}" imageWidth={${width}} imageOnLeft={${left}} topAlign={${top}}>\n${obj.content}\n</ImageTextBlock>`
-        },
-        toPreview: function (obj) {
-          const width = obj.imageWidth ?? 50
-          const textWidth = 100 - width
-          const row = obj.imageOnLeft ? '' : 'md:flex-row-reverse'
-          const align = obj.topAlign ? 'items-start' : 'items-center'
-          return `\n<div class="flex flex-col md:flex-row gap-4 w-full ${align} ${row}">\n  <img src="${obj.src}" alt="${obj.alt}" style="width:${width}%" />\n  <div style="width:${textWidth}%">${obj.content}</div>\n</div>`
-        },
-      })
-
-      CMS.registerEditorComponent({
-        id: 'soundcloud-embed',
-        label: 'SoundCloud',
-        fields: [
-          { name: 'title', label: 'Title', widget: 'string', required: false },
-          { name: 'description', label: 'Description', widget: 'string', required: false },
-          { name: 'iframe', label: 'Embed Code', widget: 'text' },
-        ],
-        // Allow any characters (including ">" from the iframe HTML) in the attribute
-        // string so the component is correctly detected by Decap.
-        pattern: /^<SoundCloudEmbed([\s\S]*?)\/>$/ms,
-        fromBlock: function (match) {
-          const attrs = match[1]
-          const get = (regex, d) => {
-            const m = attrs.match(regex)
-            return m ? m[1] : d
-          }
-          const title = get(/title="([^"]*)"/, '')
-          const description = get(/description="([^"]*)"/, '')
-          const iframe = get(/iframe={[`']([\s\S]*?)[`']}/, '')
-          return {
-            title,
-            description,
-            iframe,
-          }
-        },
-        toBlock: function (obj) {
-          const title = obj.title ?? ''
-          const description = obj.description ?? ''
-          const iframe = obj.iframe ?? ''
-          return `<SoundCloudEmbed title="${title}" description="${description}" iframe={\`${iframe}\`} />`
-        },
-        toPreview: function (obj) {
-          const title = obj.title ? `<strong>${obj.title}</strong>` : ''
-          const description = obj.description ? `<p>${obj.description}</p>` : ''
-          return `${title}${description}${obj.iframe}`
-        },
-      })
-
-      // Initialize the CMS
+      setupCMS(CMS);
       CMS.init();
     </script>
   </body>
 </html>
-


### PR DESCRIPTION
## Summary
- load Decap CMS from unpkg CDN
- initialize CMS with `setupCMS` to register `ImageTextBlock` and `SoundCloudEmbed`
- drop unused `decap-cms-app` dependency

## Testing
- `npm run lint`
- `OAUTH_GITHUB_CLIENT_ID=dummy OAUTH_GITHUB_CLIENT_SECRET=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ac8c94af88332b94fdc9c245b3028